### PR TITLE
Rename test buttons for better UX

### DIFF
--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -195,7 +195,7 @@ class DisplayTest extends Component {
             action = `You are about to leave this test run. ${cannotSave}`;
         }
         if (this.buttonAction === 'goToNextTest') {
-            modalTitle = 'Next Test';
+            modalTitle = 'Skip Test';
             action = `You are about to move to the next test. ${cannotSave}`;
         }
         if (this.buttonAction === 'goToPreviousTest') {
@@ -328,7 +328,7 @@ class DisplayTest extends Component {
                     variant="primary"
                     onClick={handleNextTestClick}
                 >
-                    Next test
+                    {this.testHasResult ? 'Next' : 'Skip'} test
                 </Button>
             </ButtonToolbar>
         );

--- a/client/components/TestIframe/index.jsx
+++ b/client/components/TestIframe/index.jsx
@@ -56,7 +56,7 @@ class TestIframe extends Component {
     // message since DOMContentLoaded is called
     // before the harness dynamically sets up the
     // test html
-    async waitForTestHarnessReload() {
+    async waitForTestHarness() {
         return new Promise(resolve => {
             const handleLoadMessage = message => {
                 if (!this.validateMessage(message, 'loaded')) return;
@@ -64,17 +64,25 @@ class TestIframe extends Component {
                 resolve();
             };
             window.addEventListener('message', handleLoadMessage);
-            // trigger reload
-            this.iframeEl.current.src = this.iframeEl.current.src; // eslint-disable-line no-self-assign
         });
     }
 
+    patchButtonName() {
+        const documentEl = this.iframeEl.current.contentDocument;
+        const buttonEl = documentEl.querySelector('#review-results');
+        buttonEl.innerText = 'Submit Results';
+    }
+
     async reloadAndClear() {
-        await this.waitForTestHarnessReload();
+        this.iframeEl.current.src = this.iframeEl.current.src; // eslint-disable-line no-self-assign
+        await this.waitForTestHarness();
+        this.patchButtonName();
     }
 
     async reloadAndHydrate(serialized) {
-        await this.waitForTestHarnessReload();
+        this.iframeEl.current.src = this.iframeEl.current.src; // eslint-disable-line no-self-assign
+        await this.waitForTestHarness();
+        this.patchButtonName();
 
         // perform the hydration from serialized form state
         const documentEl = this.iframeEl.current.contentDocument;
@@ -82,7 +90,10 @@ class TestIframe extends Component {
         hydrate(serialized, resultsEl);
     }
 
-    componentDidMount() {
+    async componentDidMount() {
+        await this.waitForTestHarness();
+        this.patchButtonName();
+
         // listen for 'results' postMessage from child iframe
         // which is sent when the "Review Results" button is clicked
         // inside the iframe

--- a/client/static/index.html
+++ b/client/static/index.html
@@ -1,12 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>ARIA-AT Reporter</title>
     <meta charset="UTF-8">
     <meta name="google" content="notranslate">
-    <meta http-equiv="Content-Language" content="en">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>ARIA-AT REPORT</title>
+    <title>ARIA-AT App</title>
     <link rel="stylesheet" href="/index.css">
 </head>
 <body>


### PR DESCRIPTION
This PR makes the following changes:
- rename "Review Results" to "Submit Results"
- rename "Next Test" to "Skip Test" if results have not been submitted.

cc @isaacdurazo as a heads up for the current instructions

Note: The "correct" fix for the "Review Results" name change is to simply change the button name on the test harness side. To avoid that change today, the `TestIframe` patches the name after load. This code is not DRY, but will be removed in a follow-up PR after the test harness has been updated for the proper fix.