### PR TITLE
Fix delete cycle foreign key constraint

### DIFF
--- a/server/services/CycleService.js
+++ b/server/services/CycleService.js
@@ -172,6 +172,12 @@ async function deleteCycle(id) {
             await db.sequelize.query(
                 `delete from tester_to_run where run_id=${run.id}`
             );
+            await db.sequelize.query(
+                `delete from test_result where run_id=${run.id}`
+            );
+            await db.sequelize.query(
+                `delete from test_issue where run_id=${run.id}`
+            );
         }
 
         await db.sequelize.query(`delete from run where test_cycle_id=${id}`);


### PR DESCRIPTION
We should be able to delete cycles. Note, delete cycles deletes all test results. Before this, if there were test results or issues filed on tests, this delete did not work.

Do we want this change in before the pilot test? Seems potentially dangerous. Myabe we should not merge this and do it the right way later, with a popup that says "Are you sure you want to delete?"