### PR TITLE
Add run status

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -19,13 +19,13 @@ sudo -u postgres yarn db-init:dev
 ### Run database migrations
 Every time a new migration file is added it must be run again to apply the migration.
 ```
-yarn run sequelize -- db:migrate
+yarn sequelize db:migrate
 ```
 
 ### Import seed data
 To import seed data into the local database
 ```
-yarn run sequelize -- db:seed:all
+yarn sequelize db:seed:all
 ```
 
 ### Import test results

--- a/server/migrations/20200528143617-add-run-status.js
+++ b/server/migrations/20200528143617-add-run-status.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+    up: (queryInterface, Sequelize) => {
+        return queryInterface.createTable('run_status', {
+            id: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            name: {
+                type: Sequelize.TEXT,
+                allowNull: false
+            }
+        });
+    },
+    down: queryInterface => {
+        return queryInterface.dropTable('run_status');
+    }
+};

--- a/server/migrations/20200528143624-add-run-status-to-run.js
+++ b/server/migrations/20200528143624-add-run-status-to-run.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+    up: (queryInterface, Sequelize) => {
+        return queryInterface.addColumn('run', 'run_status_id', {
+            type: Sequelize.INTEGER,
+            allowNull: true,
+            references: {
+                model: 'run_status',
+                key: 'id'
+            }
+        });
+    },
+
+    down: queryInterface => {
+        return queryInterface.removeColumn('run', 'run_status_id');
+    }
+};

--- a/server/migrations/20200528172804-add-run-status-to-run-data-view.js
+++ b/server/migrations/20200528172804-add-run-status-to-run-data-view.js
@@ -1,0 +1,101 @@
+'use strict';
+
+let updateViewQuery = `
+CREATE OR REPLACE VIEW run_data AS
+SELECT
+  r.id AS id,
+  r.test_cycle_id AS test_cycle_id,
+  browser_version.version AS browser_version,
+  browser.name AS browser_name,
+  browser.id AS browser_id,
+  at.key AS at_key,
+  at.id AS at_id,
+  at_name.name AS at_name,
+  at_name.id AS at_name_id,
+  at_version.version AS at_version,
+  apg_example.directory AS apg_example_directory,
+  apg_example.name AS apg_example_name,
+  apg_example.id AS apg_example_id,
+  r.run_status_id AS run_status_id,
+  r.run_status AS run_status
+FROM
+  (
+    SELECT
+      run.id as id,
+      run.test_cycle_id as test_cycle_id,
+      run.browser_version_id,
+      run.at_id,
+      run.at_version_id,
+      run.apg_example_id,
+      run_status.name as run_status,
+      run_status.id as run_status_id
+    FROM
+      run
+    LEFT JOIN run_status ON run_status.id = run.run_status_id
+  ) as r,
+  browser_version,
+  browser,
+  at,
+  at_name,
+  at_version,
+  apg_example
+WHERE
+  r.browser_version_id = browser_version.id
+  AND browser_version.browser_id = browser.id
+  AND r.at_id = at.id
+  AND at.at_name_id = at_name.id
+  AND r.at_version_id = at_version.id
+  AND r.apg_example_id = apg_example.id
+;
+`
+let originalViewQuery = `
+CREATE OR REPLACE VIEW run_data AS
+SELECT
+  run.id AS id,
+  run.test_cycle_id AS test_cycle_id,
+  browser_version.version AS browser_version,
+  browser.name AS browser_name,
+  browser.id AS browser_id,
+  at.key AS at_key,
+  at.id AS at_id,
+  at_name.name AS at_name,
+  at_name.id AS at_name_id,
+  at_version.version AS at_version,
+  apg_example.directory AS apg_example_directory,
+  apg_example.name AS apg_example_name,
+  apg_example.id AS apg_example_id
+FROM
+  run,
+  browser_version,
+  browser,
+  at,
+  at_name,
+  at_version,
+  apg_example
+WHERE
+  run.browser_version_id = browser_version.id
+  AND browser_version.browser_id = browser.id
+  AND run.at_id = at.id
+  AND at.at_name_id = at_name.id
+  AND run.at_version_id = at_version.id
+  AND run.apg_example_id = apg_example.id
+;
+`
+
+module.exports = {
+    up: (queryInterface) => {
+        return queryInterface.sequelize.query(updateViewQuery)
+
+    },
+    async down(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+        try {
+            await queryInterface.sequelize.query(`DROP VIEW IF EXISTS run_data`);
+            await queryInterface.sequelize.query(originalViewQuery);
+            await transaction.commit();
+        } catch (err) {
+            await transaction.rollback();
+            throw err;
+        }
+    }
+};

--- a/server/models/Run.js
+++ b/server/models/Run.js
@@ -47,6 +47,14 @@ module.exports = function(sequelize, DataTypes) {
                     model: 'apg_example',
                     key: 'id'
                 }
+            },
+            run_status_id: {
+                type: DataTypes.INTEGER,
+                allowNull: true,
+                references: {
+                    model: 'run_status',
+                    key: 'id'
+                }
             }
         },
         {

--- a/server/models/RunStatus.js
+++ b/server/models/RunStatus.js
@@ -1,0 +1,21 @@
+module.exports = function(sequelize, DataTypes) {
+    return sequelize.define(
+        'RunStatus',
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            name: {
+                type: DataTypes.TEXT,
+                allowNull: false
+            }
+        },
+        {
+            timestamps: false,
+            tableName: 'run_status'
+        }
+    );
+};

--- a/server/seeders/20200528145232-run_status.js
+++ b/server/seeders/20200528145232-run_status.js
@@ -4,7 +4,7 @@ module.exports = {
     up: queryInterface => {
         return queryInterface.bulkInsert(
             'run_status',
-            [{ name: 'incomplete' }, { name: 'draft' }, { name: 'final' }],
+            [{ name: 'raw' }, { name: 'draft' }, { name: 'final' }],
             {}
         );
     },

--- a/server/seeders/20200528145232-run_status.js
+++ b/server/seeders/20200528145232-run_status.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+    up: queryInterface => {
+        return queryInterface.bulkInsert(
+            'run_status',
+            [{ name: 'incomplete' }, { name: 'draft' }, { name: 'final' }],
+            {}
+        );
+    },
+    down: queryInterface => {
+        return queryInterface.bulkDelete('run_status', null, {});
+    }
+};


### PR DESCRIPTION
To test, run:
```
yarn sequelize db:migrate 
yarn sequelize db:seed:all 
```

The purpose of this change is to support the ability to mark runs as "draft" and "final', see the "status" and "action" columns as described in the test queue: https://user-images.githubusercontent.com/1379244/79916778-23833080-83de-11ea-97ea-96edb644d4d3.png