### PR TITLE
DisplayTest, StatusBar: fix button padding in two places.

### DIFF
--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -5,7 +5,6 @@ import { withRouter } from 'react-router-dom';
 import nextId from 'react-id-generator';
 import {
     Button,
-    ButtonGroup,
     ButtonToolbar,
     Col,
     Modal,
@@ -307,16 +306,7 @@ class DisplayTest extends Component {
         };
 
         let testContent = null;
-        let menuUnderContent = null;
-        let menuRightOContent = null;
-
-        let menuEditButton = this.testHasResult ? (
-            <Button variant="primary" onClick={handleEditClick}>
-                Edit
-            </Button>
-        ) : null;
-
-        menuUnderContent = (
+        let menuUnderContent = (
             <ButtonToolbar className="testrun__button-toolbar--margin">
                 {testIndex !== 1 && (
                     <Button variant="primary" onClick={handlePreviousTestClick}>
@@ -332,19 +322,39 @@ class DisplayTest extends Component {
                 </Button>
             </ButtonToolbar>
         );
-        menuRightOContent = (
-            <ButtonGroup vertical>
-                <Button variant="primary" onClick={handleRaiseIssueClick}>
+        let menuRightOContent = (
+            <>
+                <Button
+                    className="btn-block"
+                    variant="primary"
+                    onClick={handleRaiseIssueClick}
+                >
                     Raise an issue
                 </Button>
-                <Button variant="primary" onClick={handleRedoClick}>
+                <Button
+                    className="btn-block"
+                    variant="primary"
+                    onClick={handleRedoClick}
+                >
                     Re-do test
                 </Button>
-                <Button variant="primary" onClick={handleCloseRunClick}>
+                <Button
+                    className="btn-block"
+                    variant="primary"
+                    onClick={handleCloseRunClick}
+                >
                     {this.testHasResult ? 'Close' : 'Save and close'}
                 </Button>
-                {menuEditButton}
-            </ButtonGroup>
+                {this.testHasResult ? (
+                    <Button
+                        className="btn-block"
+                        variant="primary"
+                        onClick={handleEditClick}
+                    >
+                        Edit
+                    </Button>
+                ) : null}
+            </>
         );
 
         if (this.testHasResult) {

--- a/client/components/StatusBar/index.jsx
+++ b/client/components/StatusBar/index.jsx
@@ -98,7 +98,6 @@ class StatusBar extends Component {
                         </Button>
                     ) : null}
                     <Button
-                        className="ml-2"
                         variant={variant}
                         onClick={this.props.handleCloseRunClick}
                     >


### PR DESCRIPTION
Left is before, right is after: 
![image](https://user-images.githubusercontent.com/27985/83276188-40a9dc80-a19e-11ea-84a9-cef9e379e040.png)

And this: 
![image](https://user-images.githubusercontent.com/27985/83276201-46072700-a19e-11ea-8541-4e532d796daa.png)

To this: 

![image](https://user-images.githubusercontent.com/27985/83276235-4e5f6200-a19e-11ea-9a58-31a0dc484d71.png)

