### PR TITLE
active state nav styling

### DIFF
--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -36,6 +36,10 @@ nav.navbar {
     padding: 0.5rem 1rem;
 }
 
+.nav-link[aria-current="true"] {
+    color: #000;
+}
+
 main.container-fluid .row {
     padding: 0.5rem 1rem;
 }


### PR DESCRIPTION
See "Test Management" with new active state style. The other nav links also change with active state.

<img width="1181" alt="Screen Shot 2020-06-03 at 3 53 53 PM" src="https://user-images.githubusercontent.com/2789098/83683114-e1d7cf00-a5b2-11ea-84e3-5867e9ffd8ac.png">
