### PR TITLE
Fixes to initiate test run

### DIFF
--- a/client/components/ConfigureTechnologyRow/index.jsx
+++ b/client/components/ConfigureTechnologyRow/index.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Form, Row, Col } from 'react-bootstrap';
+import { Button, Form } from 'react-bootstrap';
 
 class ConfigureTechnologyRow extends Component {
     constructor(props) {
@@ -12,6 +12,7 @@ class ConfigureTechnologyRow extends Component {
         this.handleAtVersionChange = this.handleAtVersionChange.bind(this);
         this.handleBrowserChange = this.handleBrowserChange.bind(this);
         this.handleAtChange = this.handleAtChange.bind(this);
+        this.deleteRun = this.deleteRun.bind(this);
     }
 
     handleBrowserVersionChange(event) {
@@ -71,6 +72,12 @@ class ConfigureTechnologyRow extends Component {
         handleTechnologyRowChange(newRunTechnologies, index);
     }
 
+    deleteRun() {
+        const { index, deleteTechnologyRow } = this.props;
+
+        deleteTechnologyRow(index);
+    }
+
     render() {
         const {
             availableBrowsers,
@@ -80,10 +87,10 @@ class ConfigureTechnologyRow extends Component {
         } = this.props;
 
         return (
-            <Row>
-                <Col>
+            <tr>
+                <td>
                     <Form.Control
-                        aria-label={`Assistive Technology, configuration ${index}`}
+                        aria-label={`AT ${index + 1}`}
                         value={
                             runTechnologies.at_id ? runTechnologies.at_id : -1
                         }
@@ -99,17 +106,17 @@ class ConfigureTechnologyRow extends Component {
                             );
                         })}
                     </Form.Control>
-                </Col>
-                <Col>
+                </td>
+                <td>
                     <Form.Control
-                        aria-label={`Assistive Technology Version, configuration ${index}`}
+                        aria-label={`AT ${index + 1} Version`}
                         value={runTechnologies.at_version || ''}
                         onChange={this.handleAtVersionChange}
                     />
-                </Col>
-                <Col>
+                </td>
+                <td>
                     <Form.Control
-                        aria-label={`Browser, configuration ${index}`}
+                        aria-label={`Browser ${index + 1}`}
                         value={
                             runTechnologies.browser_id
                                 ? runTechnologies.browser_id
@@ -127,15 +134,25 @@ class ConfigureTechnologyRow extends Component {
                             );
                         })}
                     </Form.Control>
-                </Col>
-                <Col>
+                </td>
+                <td>
                     <Form.Control
-                        aria-label={`Browser version, configuration ${index}`}
+                        aria-label={`Browser ${index + 1} version`}
                         value={runTechnologies.browser_version || ''}
                         onChange={this.handleBrowserVersionChange}
                     />
-                </Col>
-            </Row>
+                </td>
+                <td>
+                    <Button
+                        variant="danger"
+                        aria-label={`Delete at/browser combination ${index +
+                            1}`}
+                        onClick={this.deleteRun}
+                    >
+                        Delete
+                    </Button>
+                </td>
+            </tr>
         );
     }
 }
@@ -145,7 +162,8 @@ ConfigureTechnologyRow.propTypes = {
     index: PropTypes.number,
     availableAts: PropTypes.array,
     availableBrowsers: PropTypes.array,
-    handleTechnologyRowChange: PropTypes.func
+    handleTechnologyRowChange: PropTypes.func,
+    deleteTechnologyRow: PropTypes.func
 };
 
 export default ConfigureTechnologyRow;

--- a/client/components/CycleSummary/index.jsx
+++ b/client/components/CycleSummary/index.jsx
@@ -54,8 +54,6 @@ class CycleSummary extends Component {
         }
 
         let runsByExample = {};
-        let testerByRunId = {};
-
         let technologySetTest = {};
         let technologySets = [];
 
@@ -66,7 +64,6 @@ class CycleSummary extends Component {
             } else {
                 runsByExample[run.apg_example_id] = [run];
             }
-            testerByRunId[runId] = run.testers;
 
             if (!technologySetTest[`${run.browser_name}${run.at_name}`]) {
                 technologySetTest[`${run.browser_name}${run.at_name}`] = true;
@@ -99,7 +96,7 @@ class CycleSummary extends Component {
                 <Table aria-labelledby={tableId} striped bordered hover>
                     <thead>
                         <tr>
-                            <th>Assisitve Technology</th>
+                            <th>Assistive Technology</th>
                             <th>AT Version</th>
                             <th>Browser</th>
                             <th>Browser Version</th>
@@ -121,18 +118,28 @@ class CycleSummary extends Component {
                 <h3>Test Plans</h3>
                 {testSuiteVersionData &&
                     testSuiteVersionData.apg_examples.map(example => {
+                        if (!runsByExample[example.id]) {
+                            return null;
+                        }
+
+                        let exampleTableId = nextId('table_name_');
+                        let exampleTableTitle =
+                            example.name || example.directory;
                         return (
-                            <ConfigureRunsForExample
-                                runs={runsByExample[example.id]}
-                                key={example.id}
-                                example={example}
-                                usersById={usersById}
-                                assignTesters={this.assignTesters}
-                                removeAllTestersFromRun={
-                                    this.removeAllTestersFromRun
-                                }
-                                testersByRunId={testerByRunId}
-                            />
+                            <>
+                                <h4 id={exampleTableId}>{exampleTableTitle}</h4>
+                                <ConfigureRunsForExample
+                                    runs={runsByExample[example.id]}
+                                    key={example.id}
+                                    example={example}
+                                    usersById={usersById}
+                                    assignTesters={this.assignTesters}
+                                    removeAllTestersFromRun={
+                                        this.removeAllTestersFromRun
+                                    }
+                                    tableId={exampleTableId}
+                                />
+                            </>
                         );
                     })}
             </Fragment>

--- a/client/components/InitiateCycle/index.jsx
+++ b/client/components/InitiateCycle/index.jsx
@@ -498,7 +498,7 @@ class InitiateCycle extends Component {
                             example.name || example.directory;
 
                         return (
-                            <>
+                            <Fragment key={`test-plan-${example.id}`}>
                                 <h3 id={tableId}>
                                     <input
                                         type="checkbox"
@@ -526,7 +526,7 @@ class InitiateCycle extends Component {
                                     }
                                     tableId={tableId}
                                 />
-                            </>
+                            </Fragment>
                         );
                     })}
                 {!displayExamples && (

--- a/client/components/InitiateCycle/index.jsx
+++ b/client/components/InitiateCycle/index.jsx
@@ -1,33 +1,76 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Form, Button, Row, Col } from 'react-bootstrap';
+import { Table, Form, Button, Row, Col } from 'react-bootstrap';
 import { getTestSuiteVersions, saveCycle } from '../../actions/cycles';
 import { getAllUsers } from '../../actions/users';
 import ConfigureTechnologyRow from '@components/ConfigureTechnologyRow';
 import ConfigureRunsForExample from '@components/ConfigureRunsForExample';
+import nextId from 'react-id-generator';
+
+// This is a temporary solution. Eventually this data will come from an admin page.
+function getDefaultsTechCombinations(versionData) {
+    let combos = [
+        ['JAWS', 'Chrome'],
+        ['JAWS', 'Firefox'],
+        ['NVDA', 'Chrome'],
+        ['NVDA', 'Firefox'],
+        ['VoiceOver for macOS', 'Chrome'],
+        ['VoiceOver for macOS', 'Safari']
+    ];
+
+    let initialRunRows = [];
+    for (let combo of combos) {
+        let at = versionData.supported_ats.find(at => at.at_name === combo[0]);
+        let at_id = at ? at.at_id : undefined;
+
+        let browser = versionData.browsers.find(b => b.name === combo[1]);
+        let browser_id = browser ? browser.id : undefined;
+
+        if (at_id && browser_id) {
+            initialRunRows.push({
+                at_id,
+                browser_id
+            });
+        }
+    }
+
+    return initialRunRows.length ? initialRunRows : [{}];
+}
 
 class InitiateCycle extends Component {
     constructor(props) {
         super(props);
         const { testSuiteVersions } = props;
+
+        let testSuiteVersionId = testSuiteVersions.length
+            ? testSuiteVersions[0].id
+            : undefined;
         this.state = {
-            selectedVersion: testSuiteVersions.length
-                ? testSuiteVersions[0].id
-                : undefined,
+            selectedVersion: testSuiteVersionId,
             name: '',
-            runTechnologyRows: [{}],
-            runTestersByExample: {} // example_id: runTechnolgiesIndex: [userlist]
+            runTechnologyRows: [{}], // list of {at_id, at_version, browser_id, browser_version}
+            assignedTesters: [], // list of {at_id, browser_id, example_id, tester_id}
+            exampleSelected: this.selectAllExamples(testSuiteVersionId)
         };
+
+        // This is a temporary fix until we have an admin page to control the defaults
+        if (testSuiteVersions.length) {
+            this.state.runTechnologyRows = getDefaultsTechCombinations(
+                testSuiteVersions[0]
+            );
+        }
 
         this.handleVersionChange = this.handleVersionChange.bind(this);
         this.handleNameChange = this.handleNameChange.bind(this);
         this.handleTechnologyRowChange = this.handleTechnologyRowChange.bind(
             this
         );
+        this.deleteTechnologyRow = this.deleteTechnologyRow.bind(this);
         this.addTechnologyRow = this.addTechnologyRow.bind(this);
         this.assignTesters = this.assignTesters.bind(this);
         this.removeAllTestersFromRun = this.removeAllTestersFromRun.bind(this);
+        this.selectExample = this.selectExample.bind(this);
         this.initiateCycle = this.initiateCycle.bind(this);
     }
 
@@ -49,11 +92,44 @@ class InitiateCycle extends Component {
             prevState.selectedVersion === undefined &&
             nextProps.testSuiteVersions.length > 0
         ) {
+            let versionId = nextProps.testSuiteVersions[0].id;
+            let version = nextProps.testSuiteVersions[0];
+            let exampleSelected = {};
+            for (let example of version.apg_examples) {
+                exampleSelected[example.id] = true;
+            }
+
             return {
-                selectedVersion: nextProps.testSuiteVersions[0].id
+                selectedVersion: versionId,
+                exampleSelected,
+                runTechnologyRows: getDefaultsTechCombinations(version)
             };
         }
         return null;
+    }
+
+    selectAllExamples(testSuiteVersionId) {
+        const { testSuiteVersions } = this.props;
+        if (!testSuiteVersions.length) {
+            return {};
+        }
+        let version = testSuiteVersions.find(v => v.id === testSuiteVersionId);
+        let exampleSelected = {};
+        for (let example of version.apg_examples) {
+            exampleSelected[example.id] = true;
+        }
+        return exampleSelected;
+    }
+
+    selectExample(event) {
+        const value = event.target.checked;
+        const apgExampleId = parseInt(event.target.name);
+        this.setState({
+            exampleSelected: {
+                ...this.state.exampleSelected,
+                [apgExampleId]: value
+            }
+        });
     }
 
     initiateCycle() {
@@ -94,17 +170,24 @@ class InitiateCycle extends Component {
             }
 
             for (let example of versionData.apg_examples) {
-                let runTestersByTechIndex = this.state.runTestersByExample[
-                    example.id
-                ];
+                if (!this.state.exampleSelected[example.id]) {
+                    continue;
+                }
+
+                let testers = this.state.assignedTesters
+                    .filter(t => {
+                        return (
+                            t.example_id === example.id &&
+                            t.at_id === runTechnologyPair.at_id &&
+                            t.browser_id === runTechnologyPair.browser_id
+                        );
+                    })
+                    .map(t => t.tester_id);
 
                 runs.push({
                     ...runTechnologyPair,
                     apg_example_id: example.id,
-                    users:
-                        runTestersByTechIndex && runTestersByTechIndex[index]
-                            ? runTestersByTechIndex[index]
-                            : []
+                    users: testers
                 });
             }
         }
@@ -123,38 +206,39 @@ class InitiateCycle extends Component {
     }
 
     assignTesters(exampleId, runTechnologyIndexes, userId) {
-        let testersByTechIndex = {
-            ...this.state.runTestersByExample[exampleId]
-        };
+        let newAssignedTesters = [...this.state.assignedTesters];
 
-        for (let technologyIndex of runTechnologyIndexes) {
-            if (
-                testersByTechIndex[technologyIndex] &&
-                testersByTechIndex[technologyIndex].indexOf(userId) < 0
-            ) {
-                testersByTechIndex[technologyIndex].push(userId);
-            } else {
-                testersByTechIndex[technologyIndex] = [userId];
-            }
+        for (let techIndex of runTechnologyIndexes) {
+            let techs = this.state.runTechnologyRows[techIndex];
+            newAssignedTesters.push({
+                at_id: techs.at_id,
+                browser_id: techs.browser_id,
+                example_id: exampleId,
+                tester_id: userId
+            });
         }
-        let newRunTestersByExample = { ...this.state.runTestersByExample };
-        newRunTestersByExample[exampleId] = testersByTechIndex;
-        this.setState({ runTestersByExample: newRunTestersByExample });
+
+        this.setState({
+            assignedTesters: newAssignedTesters
+        });
     }
 
     removeAllTestersFromRun(exampleId, runTechnologyIndexes) {
-        let newRunTestersByExample = { ...this.state.runTestersByExample };
-        let newRunTestersByTechIndex = {
-            ...this.state.runTestersByExample[exampleId]
-        };
+        let newAssignedTesters = [...this.state.assignedTesters];
 
-        for (let technologyIndex of runTechnologyIndexes) {
-            newRunTestersByTechIndex[technologyIndex] = [];
+        for (let techIndex of runTechnologyIndexes) {
+            let techs = this.state.runTechnologyRows[techIndex];
+            newAssignedTesters = newAssignedTesters.filter(t => {
+                return !(
+                    t.at_id === techs.at_id &&
+                    t.browser_id === techs.browser_id &&
+                    t.example_id === exampleId
+                );
+            });
         }
-        newRunTestersByExample[exampleId] = newRunTestersByTechIndex;
 
         this.setState({
-            runTestersByExample: newRunTestersByExample
+            assignedTesters: newAssignedTesters
         });
     }
 
@@ -167,8 +251,9 @@ class InitiateCycle extends Component {
 
         this.setState({
             selectedVersion: versionData.id,
-            runTechnologyRows: [{}],
-            runTestersByExample: {}
+            assignedTesters: [],
+            exampleSelected: this.selectAllExamples(versionData.id),
+            runTechnologyRows: getDefaultsTechCombinations(versionData)
         });
     }
 
@@ -195,6 +280,14 @@ class InitiateCycle extends Component {
     addTechnologyRow() {
         let newRunTechnologies = [...this.state.runTechnologyRows];
         newRunTechnologies.push({});
+        this.setState({
+            runTechnologyRows: newRunTechnologies
+        });
+    }
+
+    deleteTechnologyRow(index) {
+        let newRunTechnologies = [...this.state.runTechnologyRows];
+        newRunTechnologies.splice(index, 1);
         this.setState({
             runTechnologyRows: newRunTechnologies
         });
@@ -266,6 +359,41 @@ class InitiateCycle extends Component {
             }
         }
 
+        let displayExamples = false;
+        if (
+            this.state.runTechnologyRows.filter(run => {
+                return run.at_id && run.browser_id;
+            }).length
+        ) {
+            displayExamples = true;
+        }
+
+        let selectedPatterns = versionData.apg_examples
+            .filter(e => {
+                return this.state.exampleSelected[e.id];
+            })
+            .map(e => {
+                return e.name || e.directory;
+            });
+        let disableInitiateButton =
+            selectedPatterns.length === 0 || !displayExamples;
+
+        let listSelectedPatterns = null;
+        if (displayExamples) {
+            if (selectedPatterns.length) {
+                listSelectedPatterns = (
+                    <div>
+                        The following patterns have been selected for testing:{' '}
+                        {`${selectedPatterns.join(', ')}`}
+                    </div>
+                );
+            } else {
+                listSelectedPatterns = (
+                    <div>No patterns have been selected for testing.</div>
+                );
+            }
+        }
+
         return (
             <Fragment>
                 <h1 data-test="initiate-cycle-h2">Initiate a Test Cycle</h1>
@@ -297,26 +425,50 @@ class InitiateCycle extends Component {
                         </Col>
                     </Row>
                     <Row>
-                        <Col>Assistive Technology</Col>
-                        <Col>Version</Col>
-                        <Col>Browser</Col>
-                        <Col>Version</Col>
+                        <Table
+                            aria-label="Configure at/browser combinations for cycle"
+                            striped
+                            bordered
+                            hover
+                        >
+                            <thead>
+                                <tr>
+                                    <th>Assistive Technology</th>
+                                    <th>AT Version</th>
+                                    <th>Browser</th>
+                                    <th>Browser Version</th>
+                                    <th>Delete</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {versionData &&
+                                    this.state.runTechnologyRows.map(
+                                        (runTech, index) => {
+                                            return (
+                                                <ConfigureTechnologyRow
+                                                    key={index}
+                                                    runTechnologies={runTech}
+                                                    index={index}
+                                                    availableAts={
+                                                        versionData.supported_ats
+                                                    }
+                                                    availableBrowsers={
+                                                        versionData.browsers
+                                                    }
+                                                    handleTechnologyRowChange={
+                                                        this
+                                                            .handleTechnologyRowChange
+                                                    }
+                                                    deleteTechnologyRow={
+                                                        this.deleteTechnologyRow
+                                                    }
+                                                />
+                                            );
+                                        }
+                                    )}
+                            </tbody>
+                        </Table>
                     </Row>
-                    {versionData &&
-                        this.state.runTechnologyRows.map((runTech, index) => {
-                            return (
-                                <ConfigureTechnologyRow
-                                    key={index}
-                                    runTechnologies={runTech}
-                                    index={index}
-                                    availableAts={versionData.supported_ats}
-                                    availableBrowsers={versionData.browsers}
-                                    handleTechnologyRowChange={
-                                        this.handleTechnologyRowChange
-                                    }
-                                />
-                            );
-                        })}
                     <Row>
                         <Col>
                             <Button onClick={this.addTechnologyRow}>
@@ -326,28 +478,72 @@ class InitiateCycle extends Component {
                     </Row>
                 </Form>
                 <h2 data-test="initiate-cycle-test-plans">Test Plans</h2>
-                {versionData &&
+                {displayExamples &&
                     versionData.apg_examples.map(example => {
+                        let exampleRuns = runs.map(run => {
+                            let exampleRun = { ...run };
+                            exampleRun.testers = this.state.assignedTesters
+                                .filter(t => {
+                                    return (
+                                        t.example_id === example.id &&
+                                        t.at_id === run.at_id &&
+                                        t.browser_id === run.browser_id
+                                    );
+                                })
+                                .map(t => t.tester_id);
+                            return exampleRun;
+                        });
+                        let tableId = nextId('table_name_');
+                        let exampleTableTitle =
+                            example.name || example.directory;
+
                         return (
-                            <ConfigureRunsForExample
-                                data-test={`initiate-cycle-run-${example.id}`}
-                                newRun={true}
-                                runs={runs}
-                                key={example.id}
-                                example={example}
-                                usersById={usersById}
-                                assignTesters={this.assignTesters}
-                                removeAllTestersFromRun={
-                                    this.removeAllTestersFromRun
-                                }
-                                testersByRunId={
-                                    this.state.runTestersByExample[example.id]
-                                }
-                            />
+                            <>
+                                <h3 id={tableId}>
+                                    <input
+                                        type="checkbox"
+                                        id={`designpattern-${example.id}`}
+                                        name={example.id}
+                                        checked={
+                                            this.state.exampleSelected[
+                                                example.id
+                                            ]
+                                        }
+                                        onChange={this.selectExample}
+                                    ></input>
+                                    {exampleTableTitle}
+                                </h3>
+                                <ConfigureRunsForExample
+                                    data-test={`initiate-cycle-run-${example.id}`}
+                                    newRun={true}
+                                    runs={exampleRuns}
+                                    key={example.id}
+                                    example={example}
+                                    usersById={usersById}
+                                    assignTesters={this.assignTesters}
+                                    removeAllTestersFromRun={
+                                        this.removeAllTestersFromRun
+                                    }
+                                    tableId={tableId}
+                                />
+                            </>
                         );
                     })}
+                {!displayExamples && (
+                    <div>
+                        You must have at least one AT/Browser combination
+                        configured to review the test plans and initiate the
+                        cycle.
+                    </div>
+                )}
+                {listSelectedPatterns}
                 <div>
-                    <Button onClick={this.initiateCycle}>Initiate Cycle</Button>
+                    <Button
+                        disabled={disableInitiateButton}
+                        onClick={this.initiateCycle}
+                    >
+                        Initiate Cycle
+                    </Button>
                 </div>
             </Fragment>
         );

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -15,7 +15,10 @@ class TestQueueRow extends Component {
     constructor(props) {
         super(props);
 
-        const { totalConflicts, testsWithResults } = this.countCompleteTestsAndConflicts();
+        const {
+            totalConflicts,
+            testsWithResults
+        } = this.countCompleteTestsAndConflicts();
         this.state = {
             totalConflicts,
             testsWithResults
@@ -84,8 +87,10 @@ class TestQueueRow extends Component {
         }
 
         if (this.props.testsForRun.length !== prevProps.testsForRun.length) {
-
-            const { totalConflicts, testsWithResults } = this.countCompleteTestsAndConflicts();
+            const {
+                totalConflicts,
+                testsWithResults
+            } = this.countCompleteTestsAndConflicts();
 
             this.setState({
                 totalConflicts,

--- a/client/tests/InitiateCycle.test.jsx
+++ b/client/tests/InitiateCycle.test.jsx
@@ -139,10 +139,6 @@ describe('render', () => {
             expect(component.text()).toContain(
                 'ff1ed8a - Checkbox: Test navigating thro...'
             );
-
-            component = findByTestAttr(wrapper, 'initiate-cycle-run-1');
-            expect(component.length).toBe(1);
-            expect(component.text()).toContain('<ConfigureRunsForExample />');
         });
     });
 });


### PR DESCRIPTION
We got a lot of feedback on the initiate run page, and I tried to implement the minimal amount of it. 

The logic on this page it complicated and I could appreciate some thorough testing of both the initiate test cycle page and the cycle summary page -- both you can get to from "Test Management".

You can now select only some design patterns, and you can delete rows.