### PR TITLE
Fix bug, find expects function

### DIFF
--- a/client/utils/checkForConflict.js
+++ b/client/utils/checkForConflict.js
@@ -92,7 +92,7 @@ export default function(results, userId) {
             // unexpected behaviors
             else {
                 for (let ub of baseCommand.unexpected_behaviors) {
-                    if (!otherCommand.unexpected_behaviors.find(ub)) {
+                    if (otherCommand.unexpected_behaviors.indexOf(ub) >= 0) {
                         differentAnswers.push({
                             output: otherCommand.output,
                             answer: otherCommand.unexpected_behaviors.length


### PR DESCRIPTION
To test:
1. Fill out a test result as yourself, make sure the first command in that test has exactly one expected behavior selected. Save the result.
2. Go back and fill out the test as a different user and make sure the first command has exactly one expected behavior filled out. Save the result.
3. The app should not crash