### PR TITLE
improve test run page button UX & move Save Results button

### DIFF
--- a/client/components/DisplayTest/DisplayTest.css
+++ b/client/components/DisplayTest/DisplayTest.css
@@ -3,11 +3,19 @@
     height: 65vh;
 }
 
-.testrun__button--right {
-    position: absolute;
-    right: 0;
+.testrun__button-toolbar {
+    margin: 1em 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    flex-direction: row-reverse;
 }
 
-.testrun__button-toolbar--margin {
-    margin: 1em 0;
+.testrun__button-toolbar-group {
+    display: flex;
+    flex-direction: row-reverse;
+}
+
+.testrun__button-toolbar .btn {
+    margin-right: 0.5rem;
 }

--- a/client/components/StatusBar/index.jsx
+++ b/client/components/StatusBar/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Alert, Button, ButtonGroup } from 'react-bootstrap';
+import { Alert, Button } from 'react-bootstrap';
 import { Octicon, Octicons } from 'octicons-react';
 import nextId from 'react-id-generator';
 import {
@@ -28,7 +28,7 @@ class StatusBar extends Component {
     }
 
     async componentDidMount() {
-        const { dispatch, test, tests, testerId } = this.props;
+        const { dispatch, test, testerId } = this.props;
         let { statuses } = this.state;
 
         await dispatch(getConflictsByTestResults(test, testerId));
@@ -88,30 +88,13 @@ class StatusBar extends Component {
         if (result && result.status === 'complete') {
             let variant = 'info';
             let action = (
-                <ButtonGroup className="ml-2">
-                    {this.props.testIndex > 1 ? (
-                        <Button
-                            variant={variant}
-                            onClick={this.props.handlePreviousTestClick}
-                        >
-                            Previous
-                        </Button>
-                    ) : null}
-                    <Button
-                        variant={variant}
-                        onClick={this.props.handleCloseRunClick}
-                    >
-                        Close
-                    </Button>
-                    {this.props.testIndex < tests.length ? (
-                        <Button
-                            variant={variant}
-                            onClick={this.props.handleNextTestClick}
-                        >
-                            Next test
-                        </Button>
-                    ) : null}
-                </ButtonGroup>
+                <Button
+                    className="ml-2"
+                    variant={variant}
+                    onClick={this.props.handleNextTestClick}
+                >
+                    Next test
+                </Button>
             );
             let icon = 'info';
             let message = 'This test is complete.';


### PR DESCRIPTION
## Description

- relies on [w3c/aria-at#273](https://github.com/w3c/aria-at/pull/273) to listen for submit `postMessage` and hide inner submit button
- moves Save results to main button toolbar
- reworks main button toolbar to use primary/secondary states for clearer action
- moves Edit button from sidebar to main button toolbar
- rewords 'Re-do' to 'Start over' since re-do is ambiguous if test is in progress for first time
- removes Previous/Close buttons from test complete status bar (leaving just Next)
- changes main button toolbar tab order to move from most important button to least (right to left)

## To test

- import new aria-at test from latest revision after [w3c/aria-at#273](https://github.com/w3c/aria-at/pull/273) is merged. 
- create new test cycle from latest revision
- (temporary solution, change `server/app.js` line 33 to replace `w3c` with `s3ththompson` and `client/components/TestIframe/index.jsx` line 111 to replace `${git_hash}` with `388217a1bee40772d720f0d30aa947e8edeebd17`

## Screenshots

### In progess
<img width="1077" alt="Screen Shot 2020-06-09 at 3 18 04 PM" src="https://user-images.githubusercontent.com/970121/84190278-ac285f80-aa64-11ea-95fb-fcdc767e6038.png">

### Has results
<img width="1079" alt="Screen Shot 2020-06-09 at 3 17 51 PM" src="https://user-images.githubusercontent.com/970121/84190312-b6e2f480-aa64-11ea-9676-dc7c29e84f43.png">
