### PR TITLE
Update README setup instructions

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -12,7 +12,9 @@ The database migrations are managed by [Sequelize](https://sequelize.org/). To r
     ```
     - Linux
     ```
-    sudo -u postgres yarn db-init:dev
+    su root
+    su postgres
+    yarn db-init:dev
     ```
 2. Run database migrations
     ```

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -32,7 +32,7 @@ to information about routes, middleware and the request responce cycle.
 Additionally it adds the the ability for you use chrome dev tools and a
 `debbuger` to step through code via node's build in
 [inspector](https://nodejs.org/en/docs/guides/debugging-getting-started/). Just
-navigate to (chrome://inspect/#devices)[chrome://inspect/#devices] and open the
+navigate to [chrome://inspect/#devices](chrome://inspect/#devices) and open the
 dedicated dev tools for node.
 
 ## Testing

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -20,7 +20,7 @@
     ```
     yarn dev
     ```
-Now you can navigate your browser to: http://0.0.0.0:3000/
+Now you can navigate your browser to: [http://localhost:3000/](http://localhost:3000/). You need to use localhost instead of `0.0.0.0` because the cookie needs to be treated as secure.
 
 ## Debugging
 


### PR DESCRIPTION
- Fix markdown link syntax error
- Instruct user to use localhost instead of 0.0.0.0. Otherwise sign in doesn't work.
- Update instructions for installing db on linux.  I couldn't install for the first time on a new machine with the db command as it was written. I got the following error: `00h00m00s 0/0: : ERROR: [Errno 2] No such file or directory: 'db-init:dev'`. It was fixed with the proposed change.